### PR TITLE
Changed require for require_once

### DIFF
--- a/phpScripts/Product/MgrProduct.php
+++ b/phpScripts/Product/MgrProduct.php
@@ -13,7 +13,7 @@ Date Nom Description
  ****************************************/
 
 include_once "Product.php";
-require __DIR__ . '/../QueryEngine.php';
+require_once __DIR__ . '/../QueryEngine.php';
 //include_once("Category.php"); manque la class de cath
 
 class MgrProduct


### PR DESCRIPTION
It was conflicting with other instance of the QueryEngine in other files.
Fatal error : "cannot declare class QueryEngine because the name is already in use"